### PR TITLE
Fix number has no integer representation error

### DIFF
--- a/kucoin.lua
+++ b/kucoin.lua
@@ -216,7 +216,7 @@ function queryPrivate(method, parameters, apiVersion)
   local apiVersion = apiVersion or "v1"
   local endpoint = string.format("/api/%s/%s", apiVersion, method)
   local endpoint = endpoint .. (parameters and "?" .. parameters or "")
-  local timestamp = string.format("%d", MM.time() * 1000)
+  local timestamp = string.format("%d", math.floor(MM.time() * 1000))
   local signStr = timestamp .. "GET" .. endpoint
   local endpointSign = MM.hmac256(apiSecret, signStr)
   local passphraseSign = MM.hmac256(apiSecret, apiPassphrase)


### PR DESCRIPTION
With the recent MoneyMoney 2.4.44 version that comes with an upgraded Lua version 5.4.7, refreshing the account no longer worked with a "number has no integer representation" error on line 219. This fix explicitly converts the timestamp float value to an integer for formatting the query string.